### PR TITLE
Refactor getPublicIPv4

### DIFF
--- a/lokinet.js
+++ b/lokinet.js
@@ -209,7 +209,8 @@ const getPublicIPv4 = async (cb) => {
 
   // Wait for 2 IP results or any number of failures
   const results = await Promise.all([getIP(), getIP()])
-  if (results[0] !== results[1]) {
+  // Try again if the results are different or if they are false
+  if (results[0] !== results[1] || !results[0]) {
     // try 2 random services again
     getPublicIPv4_retries++
     if (getPublicIPv4_retries > 10) {


### PR DESCRIPTION
For review at Ryan's leisure

Simplifying getPublicIPv4 with modern JS
Previous implementation could potentially return empty string as a "successful" result if both requests return undefined
Also the same service could be used twice if the first attempt returns false for one of the calls

With this refactor `getIP()` will remove elements from the services list and try to get the ip from them until there are no elements left, resolving with either an IP string or false
If the results are different or both false, retries counter is incremented and the process is repeated

The getPublicIPv4 function is async which means that it returns a promise, and ideally this promise would just resolve with the result, but for sake of consistency with the previous implementation I left the callback argument and simply ignore the promise (but keeping the async keyword so that I can `await` inside the function)