### PR TITLE
1.0.14

### DIFF
--- a/daemon.js
+++ b/daemon.js
@@ -295,12 +295,17 @@ function launcherStorageServer(config, args, cb) {
 
   function getPidLimit(pid) {
     // linux only
-    const currentLimit = execSync(`grep 'open file' /proc/${pid}/limits`)
-    const lines = currentLimit.toString().split('\n')
-    const parts = lines[0].split(/\s{2,}/)
-    //console.log('lines', lines)
-    //console.log('parts', parts)
-    return [ parts[1], parts[2]]
+    try {
+      const currentLimit = execSync(`grep 'open file' /proc/${pid}/limits`)
+      const lines = currentLimit.toString().split('\n')
+      const parts = lines[0].split(/\s{2,}/)
+      //console.log('lines', lines)
+      //console.log('parts', parts)
+      return [ parts[1], parts[2]]
+    } catch(e) {
+      console.error('getPidLimit error', e.code, e.message)
+      return [ 0, 0 ]
+    }
   }
 
 

--- a/daemon.js
+++ b/daemon.js
@@ -334,12 +334,12 @@ function launcherStorageServer(config, args, cb) {
   // copy the output to stdout
   let storageServer_version = 'unknown'
   let stdout = '', stderr = '', collectData = true
+  let probablySyncing = false
   storageServer.stdout
     .on('data', (data) => {
-      var str = data.toString('utf8').trim()
-      if (storageLogging) console.log(`STORAGE: ${str}`)
+      const logLinesStr = data.toString('utf8').trim()
       if (collectData) {
-        const lines = str.split(/\n/)
+        const lines = logLinesStr.split(/\n/)
         for(let i in lines) {
           const tline = lines[i].trim()
           if (tline.match('Loki Storage Server v')) {
@@ -350,59 +350,107 @@ function launcherStorageServer(config, args, cb) {
             const parts = tline.split('git commit hash: ')
             fs.writeFileSync(config.launcher.var_path + '/storageServer.version', storageServer_version+"\n"+parts[1])
           }
+          if (tline.match(/pubkey_x25519_hex is missing from sn info/)) {
+            // it's be nice to know lokid was syncing
+            // but from the loki-storage logs doesn't look like it's possible to tell
+            // save some logging space
+            continue
+          }
+          if (storageLogging) console.log(`STORAGE(Start): ${tline}`)
         }
         stdout += data
-      }
-      // blockchain test
-      if (str.match(/Could not send blockchain request to Lokid/)) {
-        if (storageLogging) console.log(`STORAGE: blockchain test failure`)
-        if (!storageServer) {
-          console.log('storageServer is unset, yet getting output', str)
-          return
+      } else {
+
+
+        const lines = logLinesStr.split(/\n/)
+        for(let i in lines) {
+          const str = lines[i].trim()
+          let outputError = true
+
+          // all that don't need storageServer set
+
+          // could be testing a remote node
+          if (str.match(/Could not report node status: bad json in response/)) {
+          } else if (str.match(/Could not report node status/)) {
+          }
+          if (str.match(/Empty body on Lokid report node status/)) {
+          }
+          // end remote node
+
+          if (!storageServer) {
+            if (storageLogging && outputError) console.log(`STORAGE: ${logLinesStr}`)
+            console.log('storageServer is unset, yet getting output', logLinesStr)
+            continue
+          }
+          // all that need storageServer set
+
+          // blockchain test
+          if (str.match(/Could not send blockchain request to Lokid/)) {
+            if (storageLogging) console.log(`STORAGE: blockchain test failure`)
+            storageServer.blockchainFailures.last_blockchain_test = Date.now()
+            //communicate this out
+            lib.savePids(config, args, loki_daemon, lokinet, storageServer)
+          }
+          // blockchain ping
+          if (str.match(/Empty body on Lokid ping/) || str.match(/Could not ping Lokid. Status: {}/) ||
+              str.match(/Could not ping Lokid: bad json in response/) || str.match(/Could not ping Lokid/)) {
+            if (storageLogging) console.log(`STORAGE: blockchain ping failure`)
+            storageServer.blockchainFailures.last_blockchain_ping = Date.now()
+            //communicate this out
+            lib.savePids(config, args, loki_daemon, lokinet, storageServer)
+          }
+          // probably syncing
+          if (str.match(/Bad lokid rpc response: invalid json fields/)) {
+            probablySyncing = true
+          }
+
+          if (str.match(/pubkey_x25519_hex is missing from sn info/)) {
+            // it's be nice to know lokid was syncing
+            // but from the loki-storage logs doesn't look like it's possible to tell
+            // save some logging space
+            outputError = false // hide these
+            continue // no need to output it again
+          }
+
+          // swarm_tick communication error
+          // but happens when lokid is syncing, so we can't restart lokid
+          if (str.match(/Exception caught on swarm update: Failed to parse swarm update/)) {
+            if (probablySyncing) {
+              if (storageLogging) console.log(`STORAGE: blockchain comms failure, probably syncing`)
+              outputError = false // hide these
+              continue // no need to output it again
+            } else {
+              if (storageLogging) console.log(`STORAGE: blockchain tick failure`)
+              storageServer.blockchainFailures.last_blockchain_tick = Date.now()
+              //communicate this out
+              lib.savePids(config, args, loki_daemon, lokinet, storageServer)
+            }
+          } else if (str.match(/Exception caught on swarm update/)) {
+            if (storageLogging) console.log(`STORAGE: blockchain tick failure. Maybe syncing? ${probablySyncing}`)
+            storageServer.blockchainFailures.last_blockchain_tick = Date.now()
+            //communicate this out
+            lib.savePids(config, args, loki_daemon, lokinet, storageServer)
+          }
+          // swarm_tick communication error
+          if (str.match(/Failed to contact local Lokid/)) {
+            var ts = Date.now()
+            last120lokidContactFailures.push(ts)
+            last120lokidContactFailures.splice(-120)
+            console.log('last120lokidContactFailures', last120lokidContactFailures.length)
+            // if the oldest one is not more than 180s ago
+            if (ts - last120lokidContactFailures[0] < 180 * 1000) {
+              console.log('we should restart lokid');
+              requestBlockchainRestart();
+            }
+            if (storageLogging) console.log(`STORAGE: blockchain tick contact failure`)
+            storageServer.blockchainFailures.last_blockchain_tick = Date.now()
+            //communicate this out
+            lib.savePids(config, args, loki_daemon, lokinet, storageServer)
+          }
+          if (storageLogging && outputError) console.log(`STORAGE: ${logLinesStr}`)
         }
-        storageServer.blockchainFailures.last_blockchain_test = Date.now()
-        //communicate this out
-        lib.savePids(config, args, loki_daemon, lokinet, storageServer)
       }
-      // blockchain ping
-      if (str.match(/Empty body on Lokid ping/) || str.match(/Could not ping Lokid. Status: {}/) ||
-          str.match(/Could not ping Lokid: bad json in response/) || str.match(/Could not ping Lokid/)) {
-        if (storageLogging) console.log(`STORAGE: blockchain ping failure`)
-        if (!storageServer) {
-          console.log('storageServer is unset, yet getting output:', str)
-          return
-        }
-        storageServer.blockchainFailures.last_blockchain_ping = Date.now()
-        //communicate this out
-        lib.savePids(config, args, loki_daemon, lokinet, storageServer)
-      }
-      // swarm_tick communication error
-      if (str.match(/Failed to contact local Lokid/) || str.match(/Exception caught on swarm update/)) {
-        var ts = Date.now()
-        last120lokidContactFailures.push(ts)
-        last120lokidContactFailures.splice(-120)
-        console.log('last120lokidContactFailures', last120lokidContactFailures.length)
-        // if the oldest one is not more than 180s ago
-        if (ts - last120lokidContactFailures[0] < 180 * 1000) {
-          console.log('we should restart lokid');
-          requestBlockchainRestart();
-        }
-        if (storageLogging) console.log(`STORAGE: blockchain tick failure`)
-        if (!storageServer) {
-          console.log('storageServer is unset, yet getting output', str)
-          return
-        }
-        storageServer.blockchainFailures.last_blockchain_tick = Date.now()
-        //communicate this out
-        lib.savePids(config, args, loki_daemon, lokinet, storageServer)
-      }
-      // could be testing a remote node
-      if (str.match(/Could not report node status: bad json in response/)) {
-      } else if (str.match(/Could not report node status/)) {
-      }
-      if (str.match(/Empty body on Lokid report node status/)) {
-      }
-      // end remote node
+      //if (storageLogging) console.log(`STORAGE: ${logLinesStr}`)
     })
     .on('error', (err) => {
       console.error(`Storage Server stdout error: ${err.toString('utf8').trim()}`)
@@ -1145,6 +1193,8 @@ function launchLokid(binary_path, lokid_options, interactive, config, args, cb) 
           conn.write(data + "\n")
         }
       }
+      // FIXME: if we don't get `Received uptime-proof confirmation back from network for Service Node (yours): <24030a316d4b8379a4a7be640ee716632d40f76f2784074bcbffc4b0c617d6b7>`
+      // at least once every 2 hours, restart lokid
     })
     loki_daemon.stdout.on('error', (err) => {
       console.error('BLOCKCHAIN1_ERR:', JSON.stringify(err))

--- a/daemon.js
+++ b/daemon.js
@@ -1177,7 +1177,7 @@ function launchLokid(binary_path, lokid_options, interactive, config, args, cb) 
   }
   lib.savePids(config, args, loki_daemon, lokinet, storageServer)
 
-  if (!interactive) {
+  if (!interactive && !config.blockchain.quiet) {
     // why is the banner held back until we connect!?
     loki_daemon.stdout.on('data', (data) => {
       console.log(`blockchainRAW: ${data}`)
@@ -1579,6 +1579,10 @@ module.exports = {
   startLokinet: startLokinet,
   startStorageServer: startStorageServer,
   startLokid: startLokid,
+  // for lib::getSnodeOffline
+  configureLokid: configureLokid,
+  launchLokid: launchLokid,
+  //
   waitForLokiKey: waitForLokiKey,
   setupHandlers: setupHandlers,
   shutdown_everything: shutdown_everything,

--- a/daemon.js
+++ b/daemon.js
@@ -906,7 +906,7 @@ function startLauncherDaemon(config, interactive, entryPoint, args, debug, cb) {
 
           function runTest(test) {
             return new Promise((resolve, rej) => {
-              console.log('Starting open port check on configured ', test.name, (test.type === 'tcp' ? 'TCP':'UDP'), 'port:', test.port)
+              console.log('Starting open port check on configured', test.name, (test.type === 'tcp' ? 'TCP':'UDP'), 'port:', test.port)
               p2 = debug
               testName = 'startTestingServer'
               if (test.type === 'udp') {

--- a/index.js
+++ b/index.js
@@ -421,7 +421,11 @@ async function continueStart() {
     case 'downlaod-binaries':
     case 'download-binaries': // official
       requireRoot()
-      require(__dirname + '/modes/download-binaries').start(config)
+      const opt1 = findFirstArgWithoutDash()
+      const options = {
+        forceDownload: (opt1 === 'force')
+      }
+      require(__dirname + '/modes/download-binaries').start(config, options)
     break;
     case 'download-chain': // official
       //

--- a/index.js
+++ b/index.js
@@ -108,6 +108,7 @@ async function continueStart() {
     config_type = __dirname
   }
   config.type = config_type
+  config.entrypoint = __filename
   const lib = require(__dirname + '/lib')
 
   //console.log('Launcher config:', config)
@@ -169,6 +170,7 @@ async function continueStart() {
       if (type) {
         switch(type) {
           case 'blockchain':
+            // can hang if lokid is popping blocks
             console.log('BLOCKCHAIN STATUS')
             statusSystem.checkBlockchain();
           break;
@@ -422,13 +424,16 @@ async function continueStart() {
     case 'download-binaries': // official
       requireRoot()
       const opt1 = findFirstArgWithoutDash()
-      const options = {
+      var options = {
         forceDownload: (opt1 === 'force')
       }
       require(__dirname + '/modes/download-binaries').start(config, options)
     break;
-    case 'download-chain': // official
-      //
+    case 'download-chain':
+    case 'download-blockchain': // official
+      // doesn't have to be root but does have to be stopped
+      var options = {}
+      require(__dirname + '/modes/download-blockchain').start(config, options)
     break;
     case 'versions':
     case 'version': // official

--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ if (VERSION.match(/git/)) {
   continueStart()
 }
 
-function continueStart() {
+async function continueStart() {
   if (os.platform() == 'darwin') {
     if (process.getuid() != 0) {
       console.error('MacOS requires you start this with sudo, i.e. $ sudo ' + __filename)
@@ -142,7 +142,6 @@ function continueStart() {
 
   const statusSystem = require(__dirname + '/modes/status')
   statusSystem.start(config)
-  const status = statusSystem.status
 
   // this just show's what's installed not running
   function showVersions() {
@@ -161,23 +160,30 @@ function continueStart() {
     break;
     case 'stauts':
     case 'statsu':
+    case 'statu':
+    case 'stuatus':
+    case 'stautu':
     case 'status': // official
-      status()
+      await statusSystem.status()
       var type = findFirstArgWithoutDash()
       if (type) {
         switch(type) {
           case 'blockchain':
+            console.log('BLOCKCHAIN STATUS')
             statusSystem.checkBlockchain();
           break;
           case 'storage':
+            console.log('STORAGE STATUS')
             statusSystem.checkStorage();
           break;
           case 'network':
+            console.log('NETWORK STATUS')
             statusSystem.checkNetwork();
           break;
         }
       }
     break;
+    // no restart because we don't want people croning it
     case 'stop': // official
       // maybe use the client to see what's taking lokid a while...
       //console.log('Getting launcher state')
@@ -362,11 +368,31 @@ function continueStart() {
     break;
     case 'check-systemd':
     case 'upgrade-systemd': // official
+      // do the docs expect a specific message
+      // requireRoot()
       if (process.getuid() != 0) {
         console.log('Check-systemd needs to be ran as root, try prefixing your attempted command with: sudo')
         process.exit(1)
       }
       require(__dirname + '/modes/check-systemd').start(config, __filename)
+    break;
+    case 'systemd':
+      var type = findFirstArgWithoutDash()
+      if (type === 'enable') {
+        requireRoot()
+        // migrate or create
+        // need __filename for index location to put in service file
+        require(__dirname + '/modes/check-systemd').start(config, __filename)
+      } else
+      if (type === 'disable') {
+        requireRoot()
+        // unlink('/etc/systemd/system/lokid.service')
+      } else
+      if (type === 'log') {
+        require(__dirname + '/modes/check-systemd').launcherLogs(config)
+      } else {
+        console.log('requires one of the following parameters: enable or log')
+      }
     break;
     case 'chown':
     case 'fixperms':
@@ -390,6 +416,9 @@ function continueStart() {
       console.log('out:', args)
     break;
     case 'donwload-binaries':
+    case 'donwload-binaries':
+    case 'donwload-bianres':
+    case 'downlaod-binaries':
     case 'download-binaries': // official
       requireRoot()
       require(__dirname + '/modes/download-binaries').start(config)

--- a/index.js
+++ b/index.js
@@ -134,7 +134,7 @@ async function continueStart() {
 
   function requireRoot() {
     if (process.getuid() !== 0) {
-      console.error('This now requires to be ran as root (currentUID: ', process.getuid(), ', expected 0), try running the command with "sudo " in front')
+      console.error('This now requires to be ran as root (currentUID:', process.getuid(), ', expected 0), try running the command with "sudo " in front')
       process.exit()
     }
   }
@@ -155,6 +155,7 @@ async function continueStart() {
   switch(mode) {
     case 'strt':
     case 'strart':
+    case 'staart':
     case 'start': // official
       warnRunAsRoot()
       require(__dirname + '/start')(args, config, __filename, false)
@@ -373,7 +374,7 @@ async function continueStart() {
       // do the docs expect a specific message
       // requireRoot()
       if (process.getuid() != 0) {
-        console.log('Check-systemd needs to be ran as root, try prefixing your attempted command with: sudo')
+        console.log('upgrade-systemd needs to be ran as root, try prefixing your attempted command with: sudo')
         process.exit(1)
       }
       require(__dirname + '/modes/check-systemd').start(config, __filename)
@@ -422,8 +423,10 @@ async function continueStart() {
     case 'donwload-bianres':
     case 'downlaod-binaries':
     case 'download-binaries': // official
+      // because of lokinet and mkdirp /opt/...
       requireRoot()
       var opt1 = findFirstArgWithoutDash()
+      // FIXME: prerel-force
       var options = {
         forceDownload: (opt1 === 'force' || opt1 === 'force-prerel'),
         prerel: (opt1 === 'prerel' || opt1 === 'force-prerel')
@@ -480,22 +483,32 @@ async function continueStart() {
     default:
       console.debug('in :', process.argv)
       console.debug('out:', args)
+      //              storage    - get storage status
       console.log(`
-  Unknown mode [${mode}]
+  Unknown command [${mode}]
 
   loki-launcher is manages the Loki.network suite of software primarily for service node operation
   Usage:
-    loki-launcher [mode] [OPTIONS]
+    [sudo] loki-launcher [command] [OPTIONS]
 
-    Modes:
-      start   start the loki suite with OPTIONS
-      status  get the current loki suite status
-      client  connect to lokid
-      prequal prequalify your server for service node operation
-      download-binaries download the latest version of the loki software suite
-      check-systemd upgrade your lokid.service to use the launcher (requires root)
-      fix-perms requires user OPTION, make all operational files own by user passed in
+    Commands:
+      start       start the loki suite with OPTIONS
+      status      get the current loki suite status, can optionally provide:
+                    blockchain - get blockchain status
+      client      connect to lokid
+      prequal     prequalify your server for service node operation
       config-view print out current configuration information
+      versions    show installed versions of Loki software
+      export      try to create a compressed tarball with all the snode files
+                    that you need to migrate this snode to another host
+      systemd     requires one of the following options
+                    log - show systemd launcher log file
+
+    Commands that require root/sudo:
+      download-binaries - download the latest version of the loki software suite
+        can optionally provide: force, prerel and force-prerel
+      upgrade-systemd (check-systemd) - reconfigures your lokid.service
+      fix-perms - requires user OPTION, make all operational files own by user
   `)
     break;
   }

--- a/ini.js
+++ b/ini.js
@@ -13,7 +13,7 @@ function iniToJSON(data) {
 
     // check for section
     if (line[0] == '[' && line[line.length - 1] == ']') {
-      section = line.substring(1, line.length - 1)
+      section = line.substring(1, line.length - 1).toLowerCase()
       //console.log('found section', section)
       continue
     }

--- a/lib.js
+++ b/lib.js
@@ -80,7 +80,7 @@ function getStorageVersion(config) {
   if (storageVersion !== null) return storageVersion
   if (config.storage.binary_path && fs.existsSync(config.storage.binary_path)) {
     try {
-      const stdout = execFileSync(config.storage.binary_path, ['-v'])
+      const stdout = execFileSync(config.storage.binary_path, ['--data-dir', '/tmp', '-v'])
       const storage_version = stdout.toString().trim()
       const lines = storage_version.split(/\n/)
       //console.log('storage_version', storage_version)

--- a/lib.js
+++ b/lib.js
@@ -640,9 +640,13 @@ function stopLauncher(config) {
       if (process.getuid() !== 0) {
         console.log("this command isn't running as root, so can't stop launcher, run again with sudo")
       } else {
-        const stdoutBuf = execSync('systemctl stop lokid')
-        console.log("launcher has been stopped")
-        return
+        try {
+          const stdoutBuf = execSync('systemctl stop lokid')
+          console.log("launcher has been stopped")
+          return
+        } catch(e) {
+          console.log("stopping failed, falling back")
+        }
       }
     }
   }

--- a/lib.js
+++ b/lib.js
@@ -81,6 +81,7 @@ function getStorageVersion(config) {
   if (storageVersion !== null) return storageVersion
   if (config.storage.binary_path && fs.existsSync(config.storage.binary_path)) {
     try {
+      // data-dir has to exist to get the version
       const stdout = execFileSync(config.storage.binary_path, ['--data-dir', '/tmp', '-v'])
       const storage_version = stdout.toString().trim()
       const lines = storage_version.split(/\n/)

--- a/modes/check-systemd.js
+++ b/modes/check-systemd.js
@@ -101,6 +101,18 @@ function start(config, entrypoint) {
   }
 }
 
+function launcherLogs(config) {
+  const stdout = execSync('journalctl -u lokid')
+  console.log(stdout.toString())
+}
+
+function isActive() {
+  const stdout = execSync('systemctl is-active lokid')
+  return !stdout.toString().match(/inactive/)
+}
+
 module.exports = {
-  start: start
+  start: start,
+  launcherLogs: launcherLogs,
+  isStartedWithSystemD: isActive
 }

--- a/modes/check-systemd.js
+++ b/modes/check-systemd.js
@@ -107,12 +107,26 @@ function launcherLogs(config) {
 }
 
 function isActive() {
-  const stdout = execSync('systemctl is-active lokid')
-  return !stdout.toString().match(/inactive/)
+  try {
+    const stdout = execSync('systemctl is-active lokid')
+    return !stdout.toString().match(/inactive/)
+  } catch (e) {
+    return
+  }
+}
+
+function isEnabled(config) {
+  const stdout = execSync('systemctl is-enabled lokid')
+  // and probably should make sure it's using our entrypoint
+  // incase there's multiple snode?
+  // const stdout2 = execSync('systemctl show lokid')
+
+  return stdout.toString().match(/enabled/)
 }
 
 module.exports = {
   start: start,
   launcherLogs: launcherLogs,
-  isStartedWithSystemD: isActive
+  isStartedWithSystemD: isActive,
+  isSystemdEnabled: isEnabled,
 }

--- a/modes/check-systemd.js
+++ b/modes/check-systemd.js
@@ -116,12 +116,16 @@ function isActive() {
 }
 
 function isEnabled(config) {
-  const stdout = execSync('systemctl is-enabled lokid')
-  // and probably should make sure it's using our entrypoint
-  // incase there's multiple snode?
-  // const stdout2 = execSync('systemctl show lokid')
-
-  return stdout.toString().match(/enabled/)
+  try {
+    const stdout = execSync('systemctl is-enabled lokid')
+    // and probably should make sure it's using our entrypoint
+    // incase there's multiple snode?
+    // FIXME:
+    // const stdout2 = execSync('systemctl show lokid')
+    return stdout.toString().match(/enabled/)
+  } catch (e) {
+    return
+  }
 }
 
 module.exports = {

--- a/modes/check-systemd.js
+++ b/modes/check-systemd.js
@@ -2,7 +2,6 @@
 const fs = require('fs')
 const cp = require('child_process')
 const execSync = cp.execSync
-const lib = require(__dirname + '/../lib')
 const lokinet = require(__dirname + '/../lokinet')
 
 function rewriteServiceFile(serviceFile, entrypoint) {
@@ -71,6 +70,7 @@ function rewriteServiceFile(serviceFile, entrypoint) {
 
 // we actually currently don't use config at all... but we likely will evenutally
 function start(config, entrypoint) {
+  const lib = require(__dirname + '/../lib')
   // address issue #19
   lib.stopLauncher(config)
 

--- a/modes/download-binaries.js
+++ b/modes/download-binaries.js
@@ -242,7 +242,7 @@ function downloadGithubRepo(github_url, options, config, curVerStr, cb) {
       // tag_name, name
       var thisVer = data.tag_name.replace(/^v/, '')
       //console.log('looking at version', thisVer, '==', curVerStr)
-      if (curVerStr && curVerStr.match(thisVer)) {
+      if (curVerStr && curVerStr.match && curVerStr.match(thisVer)) {
         console.log('seems', thisVer, 'is the latest and you have', curVerStr + '! skipping')
         // no one reads the return code
         // but lets stay consistent

--- a/modes/download-binaries.js
+++ b/modes/download-binaries.js
@@ -199,6 +199,8 @@ function downloadGithubRepo(github_url, options, config, curVerStr, cb) {
       process.exit(1)
     }
 
+    // console.log('downloadGithubRepo options', options)
+
     if (data.length) {
       //console.log('Got a list of', data.length, 'releases, narrowing it down.')
       var selectedVersion = null
@@ -234,6 +236,7 @@ function downloadGithubRepo(github_url, options, config, curVerStr, cb) {
       console.log('selecting', data.name)
     }
 
+    // definitely broken for RCs...
     if (!config.forceDownload) {
       // since there's no commit rev in the data
       // FIXME: compare created_at / published_at against our dates
@@ -325,23 +328,25 @@ function start(config, options) {
   if (options.forceDownload) {
     config.forceDownload = options.forceDownload
   }
+  baseOptions = {}
+  baseOptions[options.prerel ? 'prereleaseOnly': 'notPrerelease'] = true
 
   if (config.blockchain.network == 'test' || config.blockchain.network == 'demo' || config.blockchain.network == 'staging') {
-    downloadGithubRepo('https://api.github.com/repos/loki-project/loki-network/releases', { filename: 'lokinet', useDir: true, notPrerelease: true }, config, lib.getNetworkVersion(config), function() {
+    downloadGithubRepo('https://api.github.com/repos/loki-project/loki-network/releases', { filename: 'lokinet', useDir: true, ...baseOptions }, config, lib.getNetworkVersion(config), function() {
       start_retries = 0
       lokinet.checkConfig(config) // setcap
-      downloadGithubRepo('https://api.github.com/repos/loki-project/loki-storage-server/releases', { filename: 'loki-storage', useDir: false, notPrerelease: true }, config, lib.getStorageVersion(config), function() {
+      downloadGithubRepo('https://api.github.com/repos/loki-project/loki-storage-server/releases', { filename: 'loki-storage', useDir: false, ...baseOptions }, config, lib.getStorageVersion(config), function() {
         start_retries = 0
-        downloadGithubRepo('https://api.github.com/repos/loki-project/loki-core/releases', { filename: 'lokid', useDir: true, notPrerelease: true }, config, lib.getBlockchainVersion(config), function() {
+        downloadGithubRepo('https://api.github.com/repos/loki-project/loki-core/releases', { filename: 'lokid', useDir: true, ...baseOptions }, config, lib.getBlockchainVersion(config), function() {
 
         })
       })
     })
   } else {
-    downloadGithubRepo('https://api.github.com/repos/loki-project/loki-network/releases', { filename: 'lokinet', useDir: true, notPrerelease: true }, config, lib.getNetworkVersion(config), function() {
+    downloadGithubRepo('https://api.github.com/repos/loki-project/loki-network/releases', { filename: 'lokinet', useDir: true, ...baseOptions }, config, lib.getNetworkVersion(config), function() {
       start_retries = 0
       lokinet.checkConfig(config) // setcap
-      downloadGithubRepo('https://api.github.com/repos/loki-project/loki-storage-server/releases', { filename: 'loki-storage', useDir: false, notPrerelease: true }, config, lib.getStorageVersion(config), function() {
+      downloadGithubRepo('https://api.github.com/repos/loki-project/loki-storage-server/releases', { filename: 'loki-storage', useDir: false, ...baseOptions }, config, lib.getStorageVersion(config), function() {
         start_retries = 0
         /*
         if (xenial_hack) {
@@ -349,7 +354,7 @@ function start(config, options) {
           downloadGithubRepo('https://api.github.com/repos/loki-project/loki/releases/19352901', { filename: 'lokid', useDir: true, notPrerelease: true }, config)
         } else {
         */
-        downloadGithubRepo('https://api.github.com/repos/loki-project/loki-core/releases', { filename: 'lokid', useDir: true, notPrerelease: true }, config, lib.getBlockchainVersion(config), function() {
+        downloadGithubRepo('https://api.github.com/repos/loki-project/loki-core/releases', { filename: 'lokid', useDir: true, ...baseOptions }, config, lib.getBlockchainVersion(config), function() {
           // can't run fix-perms without knowing the user
         })
         //}

--- a/modes/download-blockchain.js
+++ b/modes/download-blockchain.js
@@ -1,0 +1,170 @@
+const fs = require('fs')
+const http  = require('http')
+const https = require('https')
+const urlparser = require('url')
+// to stop the launcher
+const lib       = require(__dirname + '/../lib')
+// for mkdirp
+const lokinet   = require(__dirname + '/../lokinet')
+
+const cp  = require('child_process')
+const execSync = cp.execSync
+
+const debug = false
+
+// we need this for github header
+const VERSION = 0.3
+//console.log('loki binary downloader version', VERSION, 'registered')
+
+let xenial_hack = false
+
+// mainly different timeouts
+function downloadBlockchainFile(dest, url, cb) {
+  const urlDetails = urlparser.parse(url)
+  //console.log('downloadBlockchainFile url', urlDetails)
+  //console.log('downloadBlockchainFile', url)
+  var protoClient = http
+  if (urlDetails.protocol == 'https:') {
+    protoClient = https
+  }
+  // well somehow this can get hung on macos
+  var abort = false
+  var watchdog = setInterval(function () {
+    if (shuttingDown) {
+      //if (cb) cb()
+      // [', url, ']
+      console.log('hung httpGet but have shutdown request, calling back early and setting abort flag')
+      clearInterval(watchdog)
+      abort = true
+      cb(false)
+      return
+    }
+  }, 2 * 86400)
+  protoClient.get({
+    hostname: urlDetails.hostname,
+    protocol: urlDetails.protocol,
+    port: urlDetails.port,
+    path: urlDetails.path,
+    timeout: 5000,
+    headers: {
+      'User-Agent': 'Mozilla/5.0 Loki-launcher/' + VERSION
+    }
+  }, (resp) => {
+    //log('httpGet setting up handlers')
+    clearInterval(watchdog)
+    if (resp.statusCode === 302 || resp.statusCode === 301) {
+      if (debug) console.debug('downloadBlockchainFile - Got redirect to', resp.headers.location)
+      downloadGithubFile(dest, resp.headers.location, cb)
+      return
+    }
+    var file = fs.createWriteStream(dest, { encoding: 'binary' })
+    resp.setEncoding('binary')
+    const len = parseInt(resp.headers['content-length'], 10)
+    var downloaded = 0
+    var lastPer = 0
+    resp.on('data', function(chunk) {
+      downloaded += chunk.length
+      var tenPer = parseInt(10 * downloaded / len, 10)
+      //console.log('tenper', tenper, downloaded / len)
+      if (tenPer != lastPer) {
+        var haveMBs = downloaded / (1024 * 1024)
+        var totalMBs = len / (1024 * 1024)
+        console.log('Downloaded', (tenPer * 10) + '%', haveMBs.toFixed(2) + '/' + totalMBs.toFixed(2) +'MBi')
+        lastPer = tenPer
+      }
+    })
+    resp.pipe(file)
+    file.on('finish', function() {
+      //console.log('File download ', downloaded, '/', len, 'bytes of', url, 'complete')
+      if (downloaded < len) {
+        console.warn('file is incomplete, please try again later...')
+        fs.unlinkSync(dest)
+        process.exit(1)
+      }
+      file.close(cb)
+    })
+  }).on("error", (err) => {
+    console.error("downloadBlockchainFile - Error: " + err.message, 'port', urlDetails.port)
+    //console.log('err', err)
+    cb()
+  })
+}
+
+// FIXME: move into options
+var start_retries = 0
+function start(config, options) {
+  /*
+  const { exec } = require('child_process')
+  exec('lsb_release -c', (err, stdout, stderr) => {
+    //console.log(stdout)
+    if (stdout && stdout.match(/xenial/)) {
+      xenial_hack = true
+    }
+  })
+  */
+  // quick request so should be down by the time the file downloads...
+  lib.stopLauncher(config)
+
+  // make sure ~/.loki/data exits
+  const lmdbDir = config.blockchain.data_dir + '/lmdb'
+  console.log('lmdbDir', lmdbDir)
+  lokinet.mkDirByPathSync(lmdbDir)
+
+  var mdbFilePath = lmdbDir + '/data.mdb'
+  if (fs.existsSync(mdbFilePath)) {
+    console.log('removing old blockchain')
+    // fs.unlinkSync(mdbFilePath)
+  }
+
+  const pingMap = {}
+  function checkDone(label, value) {
+    console.log(label, 'avgPing', value)
+    pingMap[label] = value
+    if (Object.keys(pingMap).length === 2) {
+      // https://imaginary.stream/loki/data.mdb
+      // https://eu.imaginary.stream/loki/data.mdb
+      // https://eu.imaginary.stream/loki/data.mdb.md5sum
+      let url = 'https://' + (pingMap['ca'] > pingMap['eu'] ? 'eu.' : '')
+      url += 'imaginary.stream/loki/data.mdb'
+      console.log('downloading', url)
+      downloadBlockchainFile(mdbFilePath, url, function(result) {
+        if (result !== undefined) {
+          console.log('something went wrong with download, try again later or check with us')
+          process.exit(1)
+        }
+      })
+    }
+  }
+
+  console.log('detecting best source')
+  const ca = cp.execFile('/bin/ping', ['-n', '-c5', 'imaginary.stream'], function(error, stdout, stderr) {
+    if (error) console.error(error)
+    var avg = []
+    for(line of stdout.split('\n')) {
+      if (line.match(/time=/)) {
+        const parts = line.split(/time=/)
+        const ms = parts[1].replace(' ms', '')
+        avg.push(parseInt(ms * 100))
+      }
+    }
+    const avgPing = avg.reduce((a, b) => a + b, 0) / avg.length
+    checkDone('ca', avgPing)
+  })
+  const eu = cp.execFile('/bin/ping', ['-n', '-c5', 'eu.imaginary.stream'], function(error, stdout, stderr) {
+    if (error) console.error(error)
+    var avg = []
+    for(line of stdout.split('\n')) {
+      if (line.match(/time=/)) {
+        const parts = line.split(/time=/)
+        const ms = parts[1].replace(' ms', '')
+        avg.push(parseInt(ms * 100))
+      }
+    }
+    const avgPing = avg.reduce((a, b) => a + b, 0) / avg.length
+    checkDone('eu', avgPing)
+  })
+}
+
+module.exports = {
+  start: start,
+}

--- a/modes/export.js
+++ b/modes/export.js
@@ -1,0 +1,41 @@
+const fs = require('fs')
+const cp  = require('child_process')
+const execSync = cp.execSync
+
+function start(config, options) {
+  const filename = options.destPath
+
+  if (fs.existsSync(filename) || (fs.existsSync(filename + '.xz'))) {
+    console.log(filename, '(or ' + filename + '.xz) already exists please delete or specify a different file path')
+    process.exit()
+  }
+
+  execSync('tar -cf ' + filename + ' -T /dev/null')
+  //
+  function addFile(file, dir) {
+    const stripFile = file.replace(dir + '/', '')
+    // console.log('strip', dir, 'from', file, '=>', stripFile)
+    execSync('tar -C '+dir+' -rf ' + filename + ' ' + stripFile)
+  }
+  console.log('saving blockchain keys')
+  addFile(config.blockchain.lokid_key, config.blockchain.data_dir)
+  addFile(config.blockchain.lokid_edkey, config.blockchain.data_dir)
+  console.log('saving network keys')
+  addFile(config.network.data_dir + '/encryption.private', config.network.data_dir)
+  addFile(config.network.data_dir + '/transport.private', config.network.data_dir)
+  // "Shouldn't be very important, it just takes a bit longer to generate them" - Maxim S 200415
+  //console.log('saving storage keys')
+  console.log('saving storage data')
+  addFile(config.storage.data_dir + '/storage.db', config.storage.data_dir)
+  try {
+    console.log('trying to compress')
+    execSync('xz ' + filename)
+    console.log('compressed')
+  } catch(e) {
+    console.log('xz error, skipping compression')
+  }
+}
+
+module.exports = {
+  start: start,
+}

--- a/modes/prequal.js
+++ b/modes/prequal.js
@@ -253,7 +253,7 @@ module.exports = function(config, debug, timeout) {
 
       function runTest(test) {
         return new Promise((resolve, rej) => {
-          console.log('Starting open port check on configured ', test.name, (test.type === 'tcp' ? 'TCP':'UDP'), 'port:', test.port)
+          console.log('Starting open port check on configured', test.name, (test.type === 'tcp' ? 'TCP':'UDP'), 'port:', test.port)
           p2 = debug
           testName = 'startTestingServer'
           if (test.type === 'udp') {

--- a/modes/status.js
+++ b/modes/status.js
@@ -179,7 +179,7 @@ async function checkBlockchain() {
             })
           }
           resolve({
-
+            more_info: 'https://lokisn.com/sn/' + pubkey,
           })
         }
       }
@@ -203,7 +203,7 @@ async function checkBlockchain() {
       }
       lib.httpPost(url, JSON.stringify(jsonPost2), function(json) {
         const data = JSON.parse(json)
-        // console.log('result', data.result.service_node_states)
+        //console.log('result', data.result.service_node_states)
         snodeList = data.result.service_node_states
         checkDone()
       })

--- a/modes/status.js
+++ b/modes/status.js
@@ -6,7 +6,9 @@ function start(pConfig) {
   config = pConfig
 }
 
-function status() {
+const nodeVer = Number(process.version.match(/^v(\d+\.\d+)/)[1])
+
+async function status() {
   // calls areWeRunning && getPids
   var running = lib.getProcessState(config)
   var pids = lib.getPids(config)
@@ -33,7 +35,7 @@ function status() {
       lokinet.portIsFree(config.blockchain.rpc_ip, config.blockchain.rpc_port, function(portFree) {
         if (!portFree) {
           console.log('')
-          console.log('There\'s a lokid that we\'re not tracking using our configuration (rpc_port is already in use). You likely will want to confirm and manually stop it before start using the launcher again.');
+          console.log('There\'s a lokid that we\'re not tracking using our configuration (rpc_port is already in use). You likely will want to confirm and manually stop it before start using the launcher again.')
           // Exiting...
           console.log('')
           if (pids.err == 'noFile') {
@@ -42,7 +44,7 @@ function status() {
             // noFile explains why we know lokid isn't running...
           }
         }
-      });
+      })
     }
     // if we have a launcher, then ofc the port SHOULD be in use...
 
@@ -69,8 +71,7 @@ function status() {
   }
 
   // "not running" but too easy to confuse with "running"
-  lib.getLauncherStatus(config, lokinet, 'offline', function(running, checklist) {
-    var nodeVer = Number(process.version.match(/^v(\d+\.\d+)/)[1])
+  await lib.getLauncherStatus(config, lokinet, 'offline', function(running, checklist) {
     //console.log('nodeVer', nodeVer)
     if (nodeVer >= 10) {
       console.table(checklist)
@@ -83,24 +84,143 @@ function status() {
     // read config, run it with status param...
     // spawn out and relay output...
     // could also use the socket to issue a print_sn_status
+    // checkBlockchain() is best
   }
 }
 
-function checkBlockchain() {
+async function checkBlockchain() {
   var useIp = config.blockchain.rpc_ip
   if (useIp === '0.0.0.0') useIp = '127.0.0.1'
   const url = 'http://' + useIp + ':' + config.blockchain.rpc_port + '/json_rpc'
-  const jsonPost = {
-    jsonrpc: "2.0",
-    id: "0",
-    method: "get_info"
+
+  function getStatus() {
+    return new Promise(resolve => {
+      const jsonPost = {
+        jsonrpc: "2.0",
+        id: "0",
+        method: "get_info"
+      }
+      lib.httpPost(url, JSON.stringify(jsonPost), function(json) {
+        var data = JSON.parse(json)
+        //console.log('result', data.result)
+        // start_time / version is interesting
+        // outgoing_connections_count / incoming_connections_count
+        // free_space
+        // rpc_connections_count
+        const ts = parseInt(Date.now() / 1000)
+        // original function credit to https://stackoverflow.com/a/23352499
+        function secondsToRel(secondsPast) {
+          if (secondsPast === ts) {
+            return 'never'
+          }
+          if (secondsPast > 86400) {
+            return 'over a day'
+          }
+          var hours = Math.floor(secondsPast / 60 / 60)
+          if (hours) {
+            return' over an hour';
+          }
+          var minutes = Math.floor(secondsPast / 60) - (hours * 60)
+          var seconds = secondsPast % 60
+          var formatted = ''
+          formatted += minutes.toString().padStart(2, '0') + ':' + seconds.toString().padStart(2, '0')
+          return formatted
+        }
+        function tsInSecToRel(tsInSec) {
+          return secondsToRel(ts - tsInSec)
+        }
+        const status = {
+          'height': data.result.height,
+          'last_lokinet_ping': tsInSecToRel(data.result.last_lokinet_ping),
+          'last_storage_server_ping': tsInSecToRel(data.result.last_storage_server_ping),
+          'offline': data.result.offline,
+          // this is just the status of the JSON rpc call
+          //'status': data.result.status,
+        }
+        resolve(status)
+        // get_block_count
+        // console.log('block count', data.result.count)
+      })
+    })
   }
-  lib.httpPost(url, JSON.stringify(jsonPost), function(json) {
-    var data = JSON.parse(json)
-    console.log('result', data.result)
-    // get_block_count
-    // console.log('block count', data.result.count)
+
+  function getSnodeStatus() {
+    return new Promise(resolve => {
+      const jsonPost = {
+        jsonrpc: "2.0",
+        id: "0",
+        method: "get_service_node_status"
+      }
+      lib.httpPost(url, JSON.stringify(jsonPost), function(json) {
+        var data = JSON.parse(json)
+        console.log('result', data.result)
+        resolve({})
+      })
+    })
+  }
+
+  function getSnodeKeyStatus() {
+    return new Promise(async resolve => {
+      const jsonPost = {
+        jsonrpc: "2.0",
+        id: "0",
+        method: "get_service_node_key"
+      }
+      let pubkey
+      let snodeList
+      function checkDone() {
+        if (pubkey && snodeList) {
+          const ourSnode = snodeList.filter(node => node.service_node_pubkey == pubkey)
+          //console.log('ourSnode', ourSnode)
+          if (!ourSnode.length) {
+            // likely not staked yet
+            return resolve({
+              staked: false
+            })
+          }
+          resolve({
+
+          })
+        }
+      }
+      lib.httpPost(url, JSON.stringify(jsonPost), function(json) {
+        const data = JSON.parse(json)
+        //console.log('result', data.result)
+        pubkey = data.result.service_node_pubkey
+        /*
+        resolve({
+          pubkey: data.result.service_node_pubkey,
+          ed25519: data.result.service_node_ed25519_pubkey,
+          x25519: data.result.service_node_x25519_pubkey,
+        })
+        */
+        checkDone()
+      })
+      const jsonPost2 = {
+        jsonrpc: "2.0",
+        id: "0",
+        method: "get_n_service_nodes"
+      }
+      lib.httpPost(url, JSON.stringify(jsonPost2), function(json) {
+        const data = JSON.parse(json)
+        // console.log('result', data.result.service_node_states)
+        snodeList = data.result.service_node_states
+        checkDone()
+      })
+    })
+  }
+
+
+  // , getSnodeStatus() crashes unstaked 7.1.3
+  const statuses = await Promise.all([getStatus(), getSnodeKeyStatus()])
+  const status = statuses.reduce((result, current) => {
+    return Object.assign(result, current)
   })
+  if (nodeVer >= 10) {
+    console.table(status)
+  } else {
+    console.log(status)
+  }
 }
 
 function checkStorage() {

--- a/start.js
+++ b/start.js
@@ -39,14 +39,7 @@ function isNothingRunning(running) {
   return !(running.lokid || running.lokinet || running.storageServer)
 }
 
-module.exports = function(args, config, entryPoint, debug) {
-  const VERSION = 0.7
-
-  //var logo = lib.getLogo('L A U N C H E R   v e r s i o n   v version')
-  //console.log('loki SN launcher version', VERSION, 'registered')
-  const lokinet = require(__dirname + '/lokinet') // needed for checkConfig
-
-  var requested_config = config
+function setupBlockchainForStart(args, config) {
   // index.js does this already...
   //configUtil.check(config)
 
@@ -144,7 +137,18 @@ module.exports = function(args, config, entryPoint, debug) {
   setPort('zmq-rpc-bind-port', 'zmq_port')
   setPort('rpc-bind-port', 'rpc_port')
   setPort('p2p-bind-port', 'p2p_port')
+}
 
+module.exports = function(args, config, entryPoint, debug) {
+  const VERSION = 0.7
+
+  //var logo = lib.getLogo('L A U N C H E R   v e r s i o n   v version')
+  //console.log('loki SN launcher version', VERSION, 'registered')
+  const lokinet = require(__dirname + '/lokinet') // needed for checkConfig
+
+  var requested_config = config
+
+  setupBlockchainForStart(args, config)
   // launcher defaults were here...
   // lokinet defaults were here...
   // now in config.js


### PR DESCRIPTION
- introduce `status blockchain`
- introduce `systemd log`
- introduce `download-blockchain` (beta)
- introduce `export`
- download-binaries doesn't redownload binaries versions we already (unless 'download-binaries force' is used)
- added prerel & force-prerel
- integrate system enable/active detection
- work around loki-storage 2.x permissions crash
- parse INI section name case insensitively
- limit lokid max threads to 16
- catch getPidLimit exceptions
- refactor storage server logging processing
- hide CONNRESET socket server from logs
