### PR TITLE
1.0.15

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,9 @@
-[submodule "src/loki-network"]
-	path = src/loki-network
-	url = https://github.com/loki-project/loki-network.git
-[submodule "src/loki-storage-server"]
-	path = src/loki-storage-server
-	url = https://github.com/loki-project/loki-storage-server.git
-[submodule "src/loki"]
-	path = src/loki
-	url = https://github.com/Doy-lee/loki.git
+#[submodule "src/loki-network"]
+#	path = src/loki-network
+#	url = https://github.com/loki-project/loki-network.git
+#[submodule "src/loki-storage-server"]
+#	path = src/loki-storage-server
+#	url = https://github.com/loki-project/loki-storage-server.git
+#[submodule "src/loki"]
+#	path = src/loki
+#	url = https://github.com/Doy-lee/loki.git

--- a/Dockerfile.fresh
+++ b/Dockerfile.fresh
@@ -30,6 +30,7 @@ COPY modes/status.js modes/
 COPY lokinet.js .
 COPY start.js .
 COPY uid.js .
+COPY web_api.js
 
 # configure npm
 COPY package.json .

--- a/Dockerfile.fresh
+++ b/Dockerfile.fresh
@@ -30,7 +30,7 @@ COPY modes/status.js modes/
 COPY lokinet.js .
 COPY start.js .
 COPY uid.js .
-COPY web_api.js
+COPY web_api.js .
 
 # configure npm
 COPY package.json .

--- a/Dockerfile.migration
+++ b/Dockerfile.migration
@@ -55,7 +55,7 @@ COPY modes/status.js modes/
 COPY lokinet.js .
 COPY start.js .
 COPY uid.js .
-COPY web_api.js
+COPY web_api.js .
 
 # configure npm
 COPY package.json .

--- a/Dockerfile.migration
+++ b/Dockerfile.migration
@@ -55,6 +55,7 @@ COPY modes/status.js modes/
 COPY lokinet.js .
 COPY start.js .
 COPY uid.js .
+COPY web_api.js
 
 # configure npm
 COPY package.json .

--- a/Dockerfile.outdated
+++ b/Dockerfile.outdated
@@ -31,7 +31,7 @@ COPY modes/status.js modes/
 COPY lokinet.js .
 COPY start.js .
 COPY uid.js .
-COPY web_api.js
+COPY web_api.js .
 
 # place new package
 COPY package.json .

--- a/Dockerfile.outdated
+++ b/Dockerfile.outdated
@@ -31,6 +31,7 @@ COPY modes/status.js modes/
 COPY lokinet.js .
 COPY start.js .
 COPY uid.js .
+COPY web_api.js
 
 # place new package
 COPY package.json .

--- a/config.js
+++ b/config.js
@@ -289,6 +289,12 @@ function getLokidVersion(config) {
   if (config.blockchain.binary_path && fs.existsSync(config.blockchain.binary_path)) {
     try {
       var lokid_version = lib.getBlockchainVersion(config)
+      if (!lokid_version.match) {
+        // this could mean lokid fails to run
+        // (i.e. version `GLIBC_2.25' not found)
+        // if we can't get it, maybe assume the latest?
+        return false;
+      }
       //console.log('lokid_version', lokid_version)
       binary3xCache = lokid_version.match(/v3\.0/)?true:false
       binary4Xor5XCache = lokid_version.match(/v[54]\./)?true:false

--- a/config.js
+++ b/config.js
@@ -6,6 +6,8 @@ const lib = require(__dirname + '/lib')
 // only defaults we can save to disk
 // disk config is loaded over this...
 function getDefaultConfig(entrypoint) {
+  // doesn't really work like defaults
+  // if ini has one set, they're all blown out
   const config = {
     launcher: {
       prefix: '/opt/loki-launcher',
@@ -805,6 +807,13 @@ function ensureDirectoriesExist(config, uid) {
   }
 }
 
+function checkWebApiConfig(config) {
+  if (!config.web_api) config.web_api = {}
+  if (config.web_api.enabled === undefined) config.web_api.enabled = true
+  if (config.web_api.ip === undefined) config.web_api.ip = '127.0.0.1'
+  if (config.web_api.port === undefined) config.web_api.port = 22000
+}
+
 // ran after disk config is loaded
 // for everything (index.js)
 function checkConfig(config, args, debug) {
@@ -813,6 +822,7 @@ function checkConfig(config, args, debug) {
   checkBlockchainConfig(config)
   checkNetworkConfig(config)
   checkStorageConfig(config)
+  checkWebApiConfig(config)
   postcheckConfig(config)
   // this means no prequal, fix-perm, etc...
   portChecks(config) // will exit if not ok

--- a/config.js
+++ b/config.js
@@ -666,7 +666,7 @@ function portChecks(config) {
     config.blockchain.zmq_ip = '127.0.0.1'
   }
   if (config.blockchain.qun_ip === undefined) {
-    config.blockchain.qun_ip = '' // your public ip
+    config.blockchain.qun_ip = config.blockchain.p2p_ip
   }
 
   addPort(config.blockchain.p2p_ip, config.blockchain.p2p_port, 'blockchain.p2p')

--- a/daemon.js
+++ b/daemon.js
@@ -445,7 +445,9 @@ function launcherStorageServer(config, args, cb) {
             if (last120lokidContactFailures.length > 120) {
               last120lokidContactFailures.splice(-120)
             }
-            console.log('last120lokidContactFailures', last120lokidContactFailures.length, 'first', last120lokidContactFailures[0])
+            if (!shuttingDown) {
+              console.log('STORAGE: can not contact blockchain, failure count', last120lokidContactFailures.length, 'first', parseInt((ts - last120lokidContactFailures[0]) / 1000) + 's ago')
+            }
             // if the oldest one is not more than 180s ago
             if (last120lokidContactFailures.length > 120 && ts - last120lokidContactFailures[0] < 180 * 1000) {
               console.log('we should restart lokid');

--- a/daemon.js
+++ b/daemon.js
@@ -1600,7 +1600,7 @@ module.exports = {
   startLokinet: startLokinet,
   startStorageServer: startStorageServer,
   startLokid: startLokid,
-  // for lib::getSnodeOffline
+  // for lib::runOfflineBlockchainRPC
   configureLokid: configureLokid,
   launchLokid: launchLokid,
   //

--- a/index.js
+++ b/index.js
@@ -340,6 +340,7 @@ async function continueStart() {
         })
         if (!found) {
           console.warn('Could not find you being tested in', heights)
+          console.log('Please run again in a little bit (2 mins+)')
         }
       }
 

--- a/index.js
+++ b/index.js
@@ -351,7 +351,7 @@ async function continueStart() {
             }
           })
           client.on('data', (data) => {
-            var stripped = data.toString().trim()
+            var stripped = data.toString().trim().replace(/\n/, '')
             console.log('FROM SOCKET:', stripped)
           })
           client.on('end', () => {

--- a/index.js
+++ b/index.js
@@ -286,6 +286,7 @@ async function continueStart() {
       if (!running.lokid) {
         const daemon = require(__dirname + '/daemon')
         const lokinet = require('./lokinet')
+        console.log('blockchain is not running, one sec, need to start it')
         await lib.startLokidForRPC(daemon, lokinet, config)
       }
 
@@ -299,7 +300,7 @@ async function continueStart() {
 
       info = await lib.blockchainRpcGetNetInfo(config)
       if (info && info.result && info.result.height) {
-        const startHeight = info.result.height - 20
+        const startHeight = info.result.height - 11
         const endHeight = info.result.height
         // full node just has quorums up to endHeight
         console.log('Network height:', info.result.height, 'Checking for quorums between', startHeight, 'to', endHeight)
@@ -531,6 +532,7 @@ async function continueStart() {
     case 'blockchain':
       require(__dirname + '/modes/client')(config)
     break;
+    case 'preuqal':
     case 'prequal': // official
       require(__dirname + '/modes/prequal')(config, false)
     break;

--- a/index.js
+++ b/index.js
@@ -371,6 +371,7 @@ async function continueStart() {
       require(__dirname + '/start')(args, config, __filename, true)
     break;
     case 'interactive-debug':
+    case 'ineractive':
     case 'interactive':
       config.launcher.interactive = true
       process.env.__daemon = true
@@ -469,7 +470,10 @@ async function continueStart() {
         console.log('upgrade-systemd needs to be ran as root, try prefixing your attempted command with: sudo')
         process.exit(1)
       }
-      require(__dirname + '/modes/check-systemd').start(config, __filename)
+      const systemdUtils = require(__dirname + '/modes/check-systemd')
+      // we should run this even if it's not enabled
+      // as people maybe installing this file for the first time
+      systemdUtils.start(config, __filename)
     break;
     case 'systemd':
       var type = findFirstArgWithoutDash()
@@ -527,7 +531,8 @@ async function continueStart() {
         forceDownload: (opt1 === 'force' || opt1 === 'force-prerel'),
         prerel: (opt1 === 'prerel' || opt1 === 'force-prerel')
       }
-      require(__dirname + '/modes/download-binaries').start(config, options)
+      await require(__dirname + '/modes/download-binaries').start(config, options)
+      require(__dirname + '/modes/check-systemd').start(config, __filename)
     break;
     case 'download-chain':
     case 'download-blockchain': // official

--- a/index.js
+++ b/index.js
@@ -334,7 +334,7 @@ async function continueStart() {
           // console.log('test:', test)
           // height isn't set if we just started it up
           if (test.quorum.workers.indexOf(ourPubKey) !== -1) {
-            const blocks = test.height - (info.result.height - 20)
+            const blocks = test.height - (info.result.height - 11)
             console.log('You will be tested at', test.height, 'which is roughly in', blocks * 2, 'mins')
             found = true
           }

--- a/index.js
+++ b/index.js
@@ -333,7 +333,7 @@ async function continueStart() {
           // console.log('test:', test)
           // height isn't set if we just started it up
           if (test.quorum.workers.indexOf(ourPubKey) !== -1) {
-            const blocks = (test.height - 20) - info.result.height
+            const blocks = test.height - (info.result.height - 20)
             console.log('You will be tested at', test.height, 'which is roughly in', blocks * 2, 'mins')
             found = true
           }

--- a/index.js
+++ b/index.js
@@ -300,7 +300,7 @@ async function continueStart() {
       info = await lib.blockchainRpcGetNetInfo(config)
       if (info && info.result && info.result.height) {
         const startHeight = info.result.height - 20
-        const endHeight = info.result.height + 20
+        const endHeight = info.result.height
         // full node just has quorums up to endHeight
         console.log('Network height:', info.result.height, 'Checking for quorums between', startHeight, 'to', endHeight)
         const knownQuorums = {}
@@ -333,7 +333,7 @@ async function continueStart() {
           // console.log('test:', test)
           // height isn't set if we just started it up
           if (test.quorum.workers.indexOf(ourPubKey) !== -1) {
-            const blocks = test.height - info.result.height
+            const blocks = (test.height - 20) - info.result.height
             console.log('You will be tested at', test.height, 'which is roughly in', blocks * 2, 'mins')
             found = true
           }
@@ -676,16 +676,22 @@ async function continueStart() {
 
     Commands:
       start       start the loki suite with OPTIONS
+      stop        stops the launcher running in the background
       status      get the current loki suite status, can optionally provide:
                     blockchain - get blockchain status
       client      connect to lokid
       prequal     prequalify your server for service node operation
       config-view print out current configuration information
       versions    show installed versions of Loki software
-      export      try to create a compressed tarball with all the snode files
-                    that you need to migrate this snode to another host
       systemd     requires one of the following options
                     log - show systemd launcher log file
+      keys        get your service node public keys
+      show-quorum tries to give an estimate to the next time you're tested
+      export [FILENAME]   try to create a compressed tarball with all the snode files
+                            that you need to migrate this snode to another host
+      import FILENAME     try to import this exported tarball to this host
+      download-blockchain deletes current blockchain and downloads a fresh sync'd copy
+                            usually much faster than a normal lokid sync takes
 
     Commands that require root/sudo:
       download-binaries - download the latest version of the loki software suite

--- a/lib.js
+++ b/lib.js
@@ -686,7 +686,6 @@ async function getLauncherStatus(config, lokinet, offlineMessage, cb) {
 }
 
 // only stop lokid, which should stop any launcher
-// FIXME: put into stopLauncher
 function stopLokid(config) {
   var running = getProcessState(config)
   if (running.lokid) {
@@ -1189,6 +1188,7 @@ async function waitForBlockchain(config, options) {
   })
 }
 
+// FIXME: redo, so that this just starts lokid, so we can run any rpc command
 async function getSnodeOffline(statusUtils, daemon, lokinet, config) {
   daemon.config = config // update config for shutdownEverything
 
@@ -1209,7 +1209,7 @@ async function getSnodeOffline(statusUtils, daemon, lokinet, config) {
   const keys = await blockchainRpcGetKey(config)
   //console.log('rpc test result', keys.result)
   stopLokid(config)
-  return keys.result.service_node_pubkey
+  return keys.result
 }
 
 module.exports = {

--- a/lib.js
+++ b/lib.js
@@ -69,7 +69,33 @@ function getBlockchainVersion(config) {
       // Loki 'Nimble Nerthus' (v6.1.4-6f78319d0)
       return blockchainVersion
     } catch(e) {
-      console.error('Cant detect blockchain version', e)
+      /*
+Cant detect blockchain version Error: Command failed: /opt/loki-launcher/bin/lokid --version
+/opt/loki-launcher/bin/lokid: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.25' not found (required by /opt/loki-launcher/bin/lokid)
+
+    at checkExecSyncError (child_process.js:621:11)
+    at execFileSync (child_process.js:639:15)
+    at Object.getBlockchainVersion (/root/loki-daemon-launcher/lib.js:66:22)
+    at getLokidVersion (/root/loki-daemon-launcher/config.js:291:31)
+    at isBlockchainBinary3X (/root/loki-daemon-launcher/config.js:312:3)
+    at checkLauncherConfig (/root/loki-daemon-launcher/config.js:347:9)
+    at Object.checkConfig [as check] (/root/loki-daemon-launcher/config.js:821:3)
+    at continueStart (/root/loki-daemon-launcher/index.js:125:14)
+    at Object.<anonymous> (/root/loki-daemon-launcher/index.js:22:3)
+    at Module._compile (internal/modules/cjs/loader.js:936:30) {
+  status: 1,
+  signal: null,
+  output: [
+    null,
+    <Buffer >,
+    <Buffer 2f 6f 70 74 2f 6c 6f 6b 69 2d 6c 61 75 6e 63 68 65 72 2f 62 69 6e 2f 6c 6f 6b 69 64 3a 20 2f 6c 69 62 2f 78 38 36 5f 36 34 2d 6c 69 6e 75 78 2d 67 6e ... 87 more bytes>
+  ],
+  pid: 442253,
+  stdout: <Buffer >,
+  stderr: <Buffer 2f 6f 70 74 2f 6c 6f 6b 69 2d 6c 61 75 6e 63 68 65 72 2f 62 69 6e 2f 6c 6f 6b 69 64 3a 20 2f 6c 69 62 2f 78 38 36 5f 36 34 2d 6c 69 6e 75 78 2d 67 6e ... 87 more bytes>
+      */
+      // stderr seems to be already echo'd
+      console.error('Cant detect blockchain version', e.stdout.toString())
       // can't hurt to retry I guess, maybe it is a temp problem
     }
   }

--- a/modes/check-systemd.js
+++ b/modes/check-systemd.js
@@ -116,6 +116,9 @@ function isActive() {
 }
 
 function isEnabled(config) {
+  if (!fs.existsSync('/etc/systemd/system/lokid.service')) {
+    return
+  }
   try {
     const stdout = execSync('systemctl is-enabled lokid')
     // and probably should make sure it's using our entrypoint

--- a/modes/download-binaries.js
+++ b/modes/download-binaries.js
@@ -280,6 +280,7 @@ async function downloadGithubRepo(github_url, options, config, curVerStr, cb) {
         // linux
         options.ext = '.tar.xz'
         downloadArchive(asset.browser_download_url, config, options)
+        found = true
       }
       // storage server support
       if (search == 'osx' && asset.browser_download_url.match(searchRE) && asset.browser_download_url.match(/\.tar.xz/i) && asset.browser_download_url.match(/-x64-/i)) {
@@ -300,9 +301,14 @@ async function downloadGithubRepo(github_url, options, config, curVerStr, cb) {
       }
     }
     if (!found) {
-      console.log('No binary found for', search, 'for', data.name, 'searching for older version')
-      options.skips = [data.name]
-      downloadGithubRepo(github_url, options, config, curVerStr, cb)
+      if (options.skips === undefined) options.skips = []
+      options.skips.push(data.name)
+      console.log('No binary found for', search, 'for', data.name, 'searching for older version (that is not:', options.skips, ')')
+
+      // add timeout to not flood github
+      setTimeout(function() {
+        downloadGithubRepo(github_url, options, config, curVerStr, cb)
+      }, 5000 * options.skips.length)
     }
   })
 }

--- a/modes/download-binaries.js
+++ b/modes/download-binaries.js
@@ -174,7 +174,7 @@ function downloadArchive(url, config, options) {
   })
 }
 
-function downloadGithubRepo(github_url, options, config, curVerStr, cb) {
+async function downloadGithubRepo(github_url, options, config, curVerStr, cb) {
   lokinet.httpGet(github_url, function(json) {
     //console.log('got', github_url, 'result', json)
     if (json === undefined) {
@@ -206,6 +206,13 @@ function downloadGithubRepo(github_url, options, config, curVerStr, cb) {
       var selectedVersion = null
       for(var i in data) {
         const ver = data[i]
+
+        // skip if name is in the skip list
+        if (options.skips) {
+          if (options.skips.indexOf(ver.name) !== -1) {
+            continue
+          }
+        }
 
         if (options.prereleaseOnly) {
           if (ver.prerelease) {
@@ -292,6 +299,11 @@ function downloadGithubRepo(github_url, options, config, curVerStr, cb) {
         }
       }
     }
+    if (!found) {
+      console.log('No binary found for', search, 'for', data.name, 'searching for older version')
+      options.skips = [data.name]
+      downloadGithubRepo(github_url, options, config, curVerStr, cb)
+    }
   })
 }
 
@@ -322,45 +334,48 @@ function start(config, options) {
   // FIXME: this force sudo support...
   lokinet.mkDirByPathSync('/opt/loki-launcher/bin')
   console.log('Configured architecture:', process.arch)
+  return new Promise(resolve => {
 
-  // can't get draft release without authenticating as someone that can see the draft...
+    // can't get draft release without authenticating as someone that can see the draft...
 
-  if (options.forceDownload) {
-    config.forceDownload = options.forceDownload
-  }
-  baseOptions = {}
-  baseOptions[options.prerel ? 'prereleaseOnly': 'notPrerelease'] = true
+    if (options.forceDownload) {
+      config.forceDownload = options.forceDownload
+    }
+    baseOptions = {}
+    baseOptions[options.prerel ? 'prereleaseOnly': 'notPrerelease'] = true
 
-  if (config.blockchain.network == 'test' || config.blockchain.network == 'demo' || config.blockchain.network == 'staging') {
-    downloadGithubRepo('https://api.github.com/repos/loki-project/loki-network/releases', { filename: 'lokinet', useDir: true, ...baseOptions }, config, lib.getNetworkVersion(config), function() {
-      start_retries = 0
-      lokinet.checkConfig(config) // setcap
-      downloadGithubRepo('https://api.github.com/repos/loki-project/loki-storage-server/releases', { filename: 'loki-storage', useDir: false, ...baseOptions }, config, lib.getStorageVersion(config), function() {
+    if (config.blockchain.network == 'test' || config.blockchain.network == 'demo' || config.blockchain.network == 'staging') {
+      downloadGithubRepo('https://api.github.com/repos/loki-project/loki-network/releases', { filename: 'lokinet', useDir: true, ...baseOptions }, config, lib.getNetworkVersion(config), function() {
         start_retries = 0
-        downloadGithubRepo('https://api.github.com/repos/loki-project/loki-core/releases', { filename: 'lokid', useDir: true, ...baseOptions }, config, lib.getBlockchainVersion(config), function() {
-
+        lokinet.checkConfig(config) // setcap
+        downloadGithubRepo('https://api.github.com/repos/loki-project/loki-storage-server/releases', { filename: 'loki-storage', useDir: false, ...baseOptions }, config, lib.getStorageVersion(config), function() {
+          start_retries = 0
+          downloadGithubRepo('https://api.github.com/repos/loki-project/loki-core/releases', { filename: 'lokid', useDir: true, ...baseOptions }, config, lib.getBlockchainVersion(config), function() {
+            resolve()
+          })
         })
       })
-    })
-  } else {
-    downloadGithubRepo('https://api.github.com/repos/loki-project/loki-network/releases', { filename: 'lokinet', useDir: true, ...baseOptions }, config, lib.getNetworkVersion(config), function() {
-      start_retries = 0
-      lokinet.checkConfig(config) // setcap
-      downloadGithubRepo('https://api.github.com/repos/loki-project/loki-storage-server/releases', { filename: 'loki-storage', useDir: false, ...baseOptions }, config, lib.getStorageVersion(config), function() {
+    } else {
+      downloadGithubRepo('https://api.github.com/repos/loki-project/loki-network/releases', { filename: 'lokinet', useDir: true, ...baseOptions }, config, lib.getNetworkVersion(config), function() {
         start_retries = 0
-        /*
-        if (xenial_hack) {
-          console.log('Detected Xenial, forcing 4.0.5. This is temporary, until 5.1.0 supports your operating system version')
-          downloadGithubRepo('https://api.github.com/repos/loki-project/loki/releases/19352901', { filename: 'lokid', useDir: true, notPrerelease: true }, config)
-        } else {
-        */
-        downloadGithubRepo('https://api.github.com/repos/loki-project/loki-core/releases', { filename: 'lokid', useDir: true, ...baseOptions }, config, lib.getBlockchainVersion(config), function() {
-          // can't run fix-perms without knowing the user
+        lokinet.checkConfig(config) // setcap
+        downloadGithubRepo('https://api.github.com/repos/loki-project/loki-storage-server/releases', { filename: 'loki-storage', useDir: false, ...baseOptions }, config, lib.getStorageVersion(config), function() {
+          start_retries = 0
+          /*
+          if (xenial_hack) {
+            console.log('Detected Xenial, forcing 4.0.5. This is temporary, until 5.1.0 supports your operating system version')
+            downloadGithubRepo('https://api.github.com/repos/loki-project/loki/releases/19352901', { filename: 'lokid', useDir: true, notPrerelease: true }, config)
+          } else {
+          */
+          downloadGithubRepo('https://api.github.com/repos/loki-project/loki-core/releases', { filename: 'lokid', useDir: true, ...baseOptions }, config, lib.getBlockchainVersion(config), function() {
+            // can't run fix-perms without knowing the user
+            resolve()
+          })
+          //}
         })
-        //}
       })
-    })
-  }
+    }
+  })
 }
 
 module.exports = {

--- a/modes/download-blockchain.js
+++ b/modes/download-blockchain.js
@@ -113,12 +113,12 @@ function start(config, options) {
   var mdbFilePath = lmdbDir + '/data.mdb'
   if (fs.existsSync(mdbFilePath)) {
     console.log('removing old blockchain')
-    // fs.unlinkSync(mdbFilePath)
+    fs.unlinkSync(mdbFilePath)
   }
 
   const pingMap = {}
   function checkDone(label, value) {
-    console.log(label, 'avgPing', value)
+    // console.log(label, 'avgPing', value)
     pingMap[label] = value
     if (Object.keys(pingMap).length === 2) {
       // https://imaginary.stream/loki/data.mdb

--- a/modes/export.js
+++ b/modes/export.js
@@ -17,15 +17,15 @@ function start(config, options) {
     // console.log('strip', dir, 'from', file, '=>', stripFile)
     execSync('tar -C '+dir+' -rf ' + filename + ' ' + stripFile)
   }
-  console.log('saving blockchain keys')
+  console.log('exporting blockchain keys')
   addFile(config.blockchain.lokid_key, config.blockchain.data_dir)
   addFile(config.blockchain.lokid_edkey, config.blockchain.data_dir)
-  console.log('saving network keys')
+  console.log('exporting network keys')
   addFile(config.network.data_dir + '/encryption.private', config.network.data_dir)
   addFile(config.network.data_dir + '/transport.private', config.network.data_dir)
   // "Shouldn't be very important, it just takes a bit longer to generate them" - Maxim S 200415
   //console.log('saving storage keys')
-  console.log('saving storage data')
+  console.log('exporting storage data')
   addFile(config.storage.data_dir + '/storage.db', config.storage.data_dir)
   try {
     console.log('trying to compress')

--- a/modes/import.js
+++ b/modes/import.js
@@ -1,0 +1,46 @@
+const fs       = require('fs')
+const pathUtil = require('path')
+const cp       = require('child_process')
+const execSync = cp.execSync
+const lib      = require(__dirname + '/../lib')
+
+function start(config, options) {
+  lib.stopLauncher(config)
+  // deal with existing state
+
+  // back it up
+  if (fs.existsSync(config.blockchain.lokid_key)) {
+    console.log(config.blockchain.lokid_key, "exists, this has been run as a service node, backing up")
+    execSync(config.entrypoint + ' export')
+  }
+  // ok clear state
+  function deleteIfExists(file) {
+    if (fs.existsSync(file)) {
+      fs.unlinkSync(file)
+    }
+  }
+  console.log('clearing snode')
+  deleteIfExists(config.blockchain.lokid_key)
+  deleteIfExists(config.blockchain.lokid_edkey)
+  deleteIfExists(config.network.data_dir + '/encryption.private')
+  deleteIfExists(config.network.data_dir + '/transport.private')
+  deleteIfExists(config.storage.data_dir + '/storage.db')
+
+  // start import
+  const filePath = options.srcPath
+  function extractFile(file) {
+    execSync('tar xvf ' + filePath + ' -C ' + pathUtil.dirname(file) + ' ' + pathUtil.basename(file))
+  }
+  console.log('importing blockchain keys')
+  extractFile(config.blockchain.lokid_key)
+  extractFile(config.blockchain.lokid_edkey)
+  console.log('importing network keys')
+  extractFile(config.network.data_dir + '/encryption.private')
+  extractFile(config.network.data_dir + '/transport.private')
+  console.log('importing storage data')
+  extractFile(config.storage.data_dir + '/storage.db')
+}
+
+module.exports = {
+  start: start,
+}

--- a/modes/status.js
+++ b/modes/status.js
@@ -101,7 +101,16 @@ async function checkBlockchain() {
         method: "get_info"
       }
       lib.httpPost(url, JSON.stringify(jsonPost), function(json) {
-        var data = JSON.parse(json)
+        if (!json) {
+          console.log('could not get info from', url)
+          return
+        }
+        try {
+          var data = JSON.parse(json)
+        } catch (e) {
+          console.log('could not parse', json, 'as JSON')
+          return
+        }
         //console.log('result', data.result)
         // start_time / version is interesting
         // outgoing_connections_count / incoming_connections_count
@@ -152,6 +161,10 @@ async function checkBlockchain() {
         method: "get_service_node_status"
       }
       lib.httpPost(url, JSON.stringify(jsonPost), function(json) {
+        if (!json) {
+          console.log('could not get info from', url)
+          return
+        }
         var data = JSON.parse(json)
         console.log('result', data.result)
         resolve({})
@@ -184,6 +197,10 @@ async function checkBlockchain() {
         }
       }
       lib.httpPost(url, JSON.stringify(jsonPost), function(json) {
+        if (!json) {
+          console.log('could not get info from', url)
+          return
+        }
         const data = JSON.parse(json)
         //console.log('result', data.result)
         pubkey = data.result.service_node_pubkey
@@ -202,6 +219,10 @@ async function checkBlockchain() {
         method: "get_n_service_nodes"
       }
       lib.httpPost(url, JSON.stringify(jsonPost2), function(json) {
+        if (!json) {
+          console.log('could not get info from', url)
+          return
+        }
         const data = JSON.parse(json)
         //console.log('result', data.result.service_node_states)
         snodeList = data.result.service_node_states

--- a/modes/status.js
+++ b/modes/status.js
@@ -216,21 +216,15 @@ async function checkBlockchain() {
   const status = statuses.reduce((result, current) => {
     return Object.assign(result, current)
   })
-  if (nodeVer >= 10) {
-    console.table(status)
-  } else {
-    console.log(status)
-  }
+  return status
 }
 
-function checkStorage() {
-  lib.runStorageRPCTest(lokinet, config, function(data) {
-    if (data === undefined) {
-      console.log('failure')
-    } else {
-      console.log('looks good')
-    }
-  })
+async function checkStorage() {
+  let data = await lib.runStorageRPCTest(lokinet, config)
+  if (data !== undefined) {
+    return JSON.parse(data)
+  }
+  return false
   /*
   var useIp = config.storage.ip
   if (useIp === '0.0.0.0') useIp = '127.0.0.1'
@@ -246,7 +240,7 @@ function checkStorage() {
   */
 }
 
-function checkNetwork() {
+async function checkNetwork() {
   var useIp = config.network.rpc_ip
   if (useIp === '0.0.0.0') useIp = '127.0.0.1'
   const url = 'http://' + useIp + ':' + config.network.rpc_port + '/'
@@ -255,17 +249,16 @@ function checkNetwork() {
     id: "0",
     method: "llarp.version"
   }
-  lib.httpPost(url, JSON.stringify(jsonPost), function(json) {
-    console.log('json', json)
-    // 0.6.x support
-    if (json === 'bad json object') {
-      console.log('')
-    }
-    //var data = JSON.parse(json)
-    //console.log('result', data.result)
-    // get_block_count
-    // console.log('block count', data.result.count)
-  })
+  const json = await lib.httpPost(url, JSON.stringify(jsonPost))
+  console.log('json', json)
+  // 0.6.x support
+  if (json === 'bad json object') {
+    console.log('well its at least running... :(')
+  }
+  //var data = JSON.parse(json)
+  //console.log('result', data.result)
+  // get_block_count
+  // console.log('block count', data.result.count)
 }
 
 module.exports = {

--- a/web_api.js
+++ b/web_api.js
@@ -1,0 +1,62 @@
+const http = require('http')
+const lib = require(__dirname + '/lib')
+const statusSystem = require(__dirname + '/modes/status')
+const lokinet = require(__dirname + '/lokinet')
+
+// if we keep this read-only, we can't go too wrong
+
+// FIXME: caching layer...
+
+// return server handle
+function start(config) {
+  webApiServer = http.createServer(async function(request, response) {
+    //console.log('method', request.method)
+    switch(request.method) {
+      case 'GET':
+        //console.log('path', request.url)
+        switch(request.url) {
+          case '/v1/pids.json':
+            //
+            lib.getLauncherStatus(config, lokinet, 'waiting...', function(running, checklist) {
+              response.writeHead(200, {"Content-Type" : "application/json"})
+              // const combined = {...running, ...checklist}
+              response.end(JSON.stringify(running))
+            })
+          break;
+          case '/v1/health.json':
+            // , statusSystem.checkNetwork()
+            const statuses = await Promise.all([statusSystem.checkBlockchain(),
+              statusSystem.checkStorage()])
+
+            const status = statuses.reduce((result, current) => {
+              return Object.assign(result, current)
+            })
+            response.writeHead(200, {"Content-Type" : "application/json"})
+            response.end(JSON.stringify(status))
+          break;
+          case '/':
+            //response.writeHead(200, {"Content-Type" : "text/html"})
+            response.end(`
+            <a href="/v1/pids.json">pids.json</a>
+            <a href="/v1/health.json">health.json</a>
+            `)
+          break;
+          default:
+            response.writeHead(200, {"Content-Type" : "text/plain"});
+            response.end(`Unknown Path ${request.url}`);
+          break;
+        }
+      break;
+      default:
+        response.writeHead(200, {"Content-Type" : "text/plain"});
+        response.end(`Unknown Method ${request.method}`);
+      break;
+    }
+  });
+  webApiServer.listen(config.web_api.port, config.web_api.ip);
+  return webApiServer
+}
+
+module.exports = {
+  start: start,
+}

--- a/web_api.js
+++ b/web_api.js
@@ -53,7 +53,13 @@ function start(config) {
       break;
     }
   });
-  webApiServer.listen(config.web_api.port, config.web_api.ip);
+  webApiServer.listen(config.web_api.port, config.web_api.ip).on('error', function(e) {
+    if (e.code === 'EADDRINUSE') {
+      console.log('WEB_API: disabling because port', config.web_api.port, 'is inuse on', config.web_api.ip)
+    } else {
+      console.log('WEB_API:', e)
+    }
+  })
   return webApiServer
 }
 


### PR DESCRIPTION
- introduce web api (tries to bind to 22000 on localhost by default)
- introduce `show-quorum`
- introduce `import`
- introduce `keys`
- fix `download-blockchain`
- centos8 fixes
- turn off always showing the logo
- fix qun_ip (it's tied to the p2p_ip)
- trim new lines from `stop` blockchain output
- `download-binaries` now just runs `check-system` if systemd is enabled
- `download-binaries` fall back to last release if the current one doesn't have a binary for your platform
- improve `status blockchain` error handling